### PR TITLE
https patch

### DIFF
--- a/html/ui/index.html
+++ b/html/ui/index.html
@@ -7,7 +7,7 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <!--atcrowdfund-->
         <!--end-->
-        <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
+        <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
         <link href="css/font-awesome.min.css" rel="stylesheet" type="text/css"  />
         <link href="css/ionicons.min.css" rel="stylesheet" type="text/css" />
         <link href="css/app.css" rel="stylesheet" type="text/css" />
@@ -18,7 +18,7 @@
         <style id="user_boxes_style" type="text/css"></style>
         <!-- Reconsider this jquery input as its a multiple of the one in 3rd party folder, one posibility might be to add jquery here but remove from 3rd party
             same with the import i removed for bootstrap.js. Duplicate imports for scripts might cause some spectacular and hard to trace bugs -->
-        <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" type="text/javascript"></script>
+        <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" type="text/javascript"></script>
         <style>
             .animate-change {
     		background-color:green;
@@ -215,7 +215,7 @@
             margin: 0.5em 0.5em;
             }
         </style>
-        <!--script type="text/javascript" src="https://code.jquery.com/ui/1.10.4/jquery-ui.min.js" type="text/javascript"></script-->
+        <!--script type="text/javascript" src="//code.jquery.com/ui/1.10.4/jquery-ui.min.js" type="text/javascript"></script-->
     </head>
     <body class="lockscreen fixed">
         <div id="lockscreen">

--- a/html/ui/js/nrs.crowdfunding.js
+++ b/html/ui/js/nrs.crowdfunding.js
@@ -23,7 +23,7 @@ $('#buy-ticket').on('click', function(e) {
 		deadline: 100
 	}
 	$.ajax({
-		url: 'http://' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
+		url: '//' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
 		type: 'POST',
 		dataType: "json",
 		data: jsonRequest,
@@ -80,7 +80,7 @@ $('#deploy-at-btn').on('click', function(e) {
 		minActivationAmountNQT: minA
 	}
 	$.ajax({
-		url: 'http://' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
+		url: '//' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
 		type: 'POST',
 		dataType: "json",
 		data: jsonRequest,
@@ -146,7 +146,7 @@ $(document).ready(function() {
 		});
 	});
 	$.ajax({
-		url: 'http://' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
+		url: '//' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
 		type: 'POST',
 		dataType: "json",
 		data: "requestType=getATIds",
@@ -200,7 +200,7 @@ function getAT(atId) {
 		at: atId
 	}
 	$.ajax({
-		url: 'http://' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
+		url: '//' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
 		type: 'POST',
 		dataType: "json",
 		data: jsonRequest,
@@ -215,7 +215,7 @@ function getBlockHeight(atData) {
 		requestType: "getBlockchainStatus"
 	}
 	$.ajax({
-		url: 'http://' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
+		url: '//' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
 		type: 'POST',
 		dataType: "json",
 		data: jsonRequest,
@@ -231,7 +231,7 @@ function getTransaction(blockHeight, atData) {
 		hexString: atData.machineData.substring(1 * 8, 1 * 8 + 8)
 	}
 	$.ajax({
-		url: 'http://' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
+		url: '//' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
 		type: 'POST',
 		dataType: "json",
 		data: jsonRequest,
@@ -247,7 +247,7 @@ function getDecision(transaction, blockHeight, atData) {
 		hexString: atData.machineData.substring(1 * 16, 1 * 16 + 16)
 	}
 	$.ajax({
-		url: 'http://' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
+		url: '//' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
 		type: 'POST',
 		dataType: "json",
 		data: jsonRequest,
@@ -263,7 +263,7 @@ function getTargetAmount(decision, transaction, blockHeight, atData) {
 		hexString: atData.machineData.substring(3 * 16, 3 * 16 + 16)
 	}
 	$.ajax({
-		url: 'http://' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
+		url: '//' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
 		type: 'POST',
 		dataType: "json",
 		data: jsonRequest,
@@ -279,7 +279,7 @@ function getGatheredAmount(targetAmount, decision, transaction, blockHeight, atD
 		hexString: atData.machineData.substring(2 * 16, 2 * 16 + 16)
 	}
 	$.ajax({
-		url: 'http://' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
+		url: '//' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
 		type: 'POST',
 		dataType: "json",
 		data: jsonRequest,
@@ -295,7 +295,7 @@ function getFunded(gatheredAmount, targetAmount, decision, transaction, blockHei
 		hexString: atData.machineData.substring(7 * 16, 7 * 16 + 16)
 	}
 	$.ajax({
-		url: 'http://' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
+		url: '//' + window.location.hostname.toLowerCase() + ':' + window.location.port + '/burst',
 		type: 'POST',
 		dataType: "json",
 		data: jsonRequest,

--- a/html/ui/rewardassignment.html
+++ b/html/ui/rewardassignment.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <link href="http://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
+    <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet" type="text/css" />
   </head>
   <body class="container">
     <div>


### PR DESCRIPTION
By using HTTPS (apiSSL = true) browsers block certain traffic due to mixed-content restrictions.
This patch switches from hardcoded "http://" references for external resources and ajax requests to a more compatible "//" format.

This fixes issue #17 